### PR TITLE
Stop crashes when connecting to autotracking

### DIFF
--- a/src/AutoTracking.gd
+++ b/src/AutoTracking.gd
@@ -218,7 +218,7 @@ func _on_data():
         _client.get_peer(1).put_packet(JSON.print(connect_data).to_utf8())
         Events.emit_signal('set_connected_device', device_index)
         if (device.length() > 23):
-            status_label.text = "Connected to " + device.substring(0, 20) + "..."
+            status_label.text = "Connected to " + device.substr(0, 20) + "..."
         else:
             status_label.text = "Connected to " + device
 


### PR DESCRIPTION
When connecting to auto tracking if the device name is longer than 23 characters e.g. "emunwa://<>" or "luabridge://<>" the program will crash with `Invalid call. Nonexistent function 'substring' in base 'String'.`

Changing this to the correct `.substr()` allows for autotracking to be used. (im assuming you tested in retro arch which is "ra://" or ipv6 which both would be less than 23 characters)